### PR TITLE
handle common block and start-address 768 and 1706

### DIFF
--- a/src/smart_meter.h
+++ b/src/smart_meter.h
@@ -30,7 +30,6 @@ public:
             return OnModbusReceiveRequest(request);
         })
         , m_dlmsMeter(uartMbus)
-        , m_meterModel(SMART_METER_ADDRESS)
     {
         // test-hack
         // const auto beginPlus = 16481.152f;

--- a/src/smart_meter.yaml
+++ b/src/smart_meter.yaml
@@ -319,7 +319,7 @@ text_sensor:
     id: energy_interval_settings
     update_interval: never
   - platform: template
-    name: 1.7 Gerätelaufzeit V25.04.10
+    name: 1.7 Gerätelaufzeit V26.06.01
     id: device_uptime
     update_interval: never
   - platform: template

--- a/src/sunspec_meter_model.h
+++ b/src/sunspec_meter_model.h
@@ -23,7 +23,7 @@ constexpr auto REGISTER_TOTAL_COUNT = REGISTER_COMMON_COUNT + REGISTER_METER_COU
 class MeterModel : public modb::ModbusRegisters
 {
 public:
-    MeterModel(uint8_t modbusAddress)
+    MeterModel()
         : modb::ModbusRegisters(REGISTER_OFFSET, REGISTER_TOTAL_COUNT)
     {
         // Init static data
@@ -32,13 +32,14 @@ public:
         SetRegisterUint16(2, 0x0001);
         SetRegisterUint16(3, REGISTER_COMMON_COUNT - 4); // Number of registers in this block following this entry
 
-        SetRegisterString(4, ":)", 16);
-
-        SetRegisterString(20, "Kai2SunMod", 24);
-
-        SetRegisterString(44, "V0.1.0", 24);
-
-        SetRegisterUint16(68, modbusAddress);
+        // Note: The entries in 4 to 68 are mandatory,
+        // otherwise Smart Meter is not recognized with gen24 - inverter SW version 1.40.9-1
+        SetRegisterString(4, "Fronius", 16);
+        SetRegisterString(20, "Smart Meter 63A", 16);
+        SetRegisterString(36, "<primary>", 8);
+        SetRegisterString(44, "1.0", 8);
+        SetRegisterString(52, "18370117", 16);
+        SetRegisterUint16(68, 240);
 
         // Meter block
         SetRegisterUint16(69, 213); // float, 3-phase meter.
@@ -51,6 +52,19 @@ public:
 
     virtual ~MeterModel() { }
 
+    virtual modb::ResponseError Read(const uint16_t registerAddress, const uint16_t registerCount, uint8_t* target) const
+    {
+        // Handle registers that return 0
+        if ((registerAddress == 768 || registerAddress == 1706) && registerCount == 1)
+        {
+            target[0] = 0;
+            target[1] = 0;
+            return modb::ResponseError::None;
+        }
+
+        return modb::ModbusRegisters::Read(registerAddress, registerCount, target);
+    }
+
     virtual modb::ResponseError Write(const uint16_t /*registerAddress*/, const uint16_t /*registerCount*/, const uint8_t* /*source*/)
     {
         // Not supported
@@ -59,51 +73,51 @@ public:
 
     void SetAcCurrent(float total, float phaseA, float phaseB, float phaseC)
     {
-        SetFloats(71, {total, phaseA, phaseB, phaseC});
+        SetFloats(71, { total, phaseA, phaseB, phaseC });
     }
     void SetVoltageToNeutral(float average, float phaseA, float phaseB, float phaseC)
     {
-        SetFloats(79, {average, phaseA, phaseB, phaseC});
+        SetFloats(79, { average, phaseA, phaseB, phaseC });
     }
     void SetVoltagePhaseToPhase(float average, float phaseAB, float phaseBC, float phaseCA)
     {
-        SetFloats(87, {average, phaseAB, phaseBC, phaseCA});
+        SetFloats(87, { average, phaseAB, phaseBC, phaseCA });
     }
     void SetFrequency(float value)
     {
-        SetFloats(95, {value});
+        SetFloats(95, { value });
     }
     void SetPower(float total, float phaseA, float phaseB, float phaseC)
     {
-        SetFloats(97, {total, phaseA, phaseB, phaseC});
+        SetFloats(97, { total, phaseA, phaseB, phaseC });
     }
     void SetApparentPower(float total, float phaseA, float phaseB, float phaseC)
     {
-        SetFloats(105, {total, phaseA, phaseB, phaseC});
+        SetFloats(105, { total, phaseA, phaseB, phaseC });
     }
     void SetReactivePower(float total, float phaseA, float phaseB, float phaseC)
     {
-        SetFloats(113, {total, phaseA, phaseB, phaseC});
+        SetFloats(113, { total, phaseA, phaseB, phaseC });
     }
     void SetPowerFactor(float total, float phaseA, float phaseB, float phaseC) // cos-phi
     {
-        SetFloats(121, {total, phaseA, phaseB, phaseC});
+        SetFloats(121, { total, phaseA, phaseB, phaseC });
     }
     void SetTotalWattHoursExported(float total, float phaseA, float phaseB, float phaseC)
     {
-        SetFloats(129, {total, phaseA, phaseB, phaseC});
+        SetFloats(129, { total, phaseA, phaseB, phaseC });
     }
     void SetTotalWattHoursImported(float total, float phaseA, float phaseB, float phaseC)
     {
-        SetFloats(137, {total, phaseA, phaseB, phaseC});
+        SetFloats(137, { total, phaseA, phaseB, phaseC });
     }
     void SetTotalVaHoursExported(float total, float phaseA, float phaseB, float phaseC)
     {
-        SetFloats(145, {total, phaseA, phaseB, phaseC});
+        SetFloats(145, { total, phaseA, phaseB, phaseC });
     }
     void SetTotalVaHoursImported(float total, float phaseA, float phaseB, float phaseC)
     {
-        SetFloats(153, {total, phaseA, phaseB, phaseC});
+        SetFloats(153, { total, phaseA, phaseB, phaseC });
     }
     // Rest is not needed
 };

--- a/test/sunspec_meter_model_test.cpp
+++ b/test/sunspec_meter_model_test.cpp
@@ -8,7 +8,6 @@ using namespace testutils;
 namespace
 {
 
-constexpr uint8_t MODBUS_ADDRESS = 0x01;
 constexpr auto VALUE1 = 1.1f;
 constexpr auto VALUE2 = 22.22f;
 constexpr auto VALUE3 = 333.333f;
@@ -28,7 +27,7 @@ protected:
         ASSERT_EQ(ToFloatLittleEndian(&reg[6]), VALUE4);
     }
 
-    MeterModel m_meter{MODBUS_ADDRESS};
+    MeterModel m_meter;
 };
 
 TEST_F(SunspecMeterModelTest, Constructor_InitializedRegisters)
@@ -42,17 +41,16 @@ TEST_F(SunspecMeterModelTest, Constructor_InitializedRegisters)
     ASSERT_EQ(__builtin_bswap32(*(uint32_t*)&reg[0]), 0x53756e53); // same test as before
     ASSERT_EQ(__builtin_bswap16(reg[2]), 1);
     ASSERT_EQ(__builtin_bswap16(reg[3]), 65);
-    ASSERT_EQ(__builtin_bswap16(reg[4]), 0x3A29); // ":)"
-    ASSERT_EQ(IsEqualString(&reg[20], "Kai2SunMod"), true);
-    ASSERT_EQ(__builtin_bswap16(reg[68]), MODBUS_ADDRESS);
+    ASSERT_EQ(IsEqualString(&reg[4], "Fronius"), true);
+    ASSERT_EQ(IsEqualString(&reg[20], "Smart Meter 63A"), true);
+    ASSERT_EQ(IsEqualString(&reg[36], "<primary>"), true);
+    ASSERT_EQ(IsEqualString(&reg[44], "1.0"), true);
+    ASSERT_EQ(IsEqualString(&reg[52], "18370117"), true);
+    ASSERT_EQ(__builtin_bswap16(reg[68]), 240);
     ASSERT_EQ(__builtin_bswap16(reg[69]), 213);
     ASSERT_EQ(__builtin_bswap16(reg[70]), 124);
     ASSERT_EQ(__builtin_bswap16(reg[195]), 0xFFFF);
     ASSERT_EQ(__builtin_bswap16(reg[196]), 0);
-    for (size_t i = 47; i < 68; i++)
-    {
-        ASSERT_EQ(reg[i], 0);
-    }
     for (size_t i = 71; i < 195; i++)
     {
         ASSERT_EQ(reg[i], 0);
@@ -184,6 +182,42 @@ TEST_F(SunspecMeterModelTest, Read_InvalidCount_ReturnsError)
     const auto address = sunspec::REGISTER_OFFSET;
     const auto count = sunspec::REGISTER_TOTAL_COUNT + 1;
     std::vector<uint8_t> data(count * sizeof(uint16_t));
+    ASSERT_EQ(m_meter.Read(address, count, &data[0]), modb::ResponseError::IllegalAddress);
+}
+
+TEST_F(SunspecMeterModelTest, Read_ValidAddress768_ReturnsOk)
+{
+    const auto address = 768;
+    const auto count = 1;
+    std::vector<uint8_t> data(count * modb::REGISTER_SIZE);
+    ASSERT_EQ(m_meter.Read(address, count, &data[0]), modb::ResponseError::None);
+    ASSERT_EQ(data[0], 0);
+    ASSERT_EQ(data[1], 0);
+}
+
+TEST_F(SunspecMeterModelTest, Read_InvalidAddress768Count_ReturnsError)
+{
+    const auto address = 768;
+    const auto count = 2;
+    std::vector<uint8_t> data(count * modb::REGISTER_SIZE);
+    ASSERT_EQ(m_meter.Read(address, count, &data[0]), modb::ResponseError::IllegalAddress);
+}
+
+TEST_F(SunspecMeterModelTest, Read_ValidAddress1706_ReturnsOk)
+{
+    const auto address = 1706;
+    const auto count = 1;
+    std::vector<uint8_t> data(count * modb::REGISTER_SIZE);
+    ASSERT_EQ(m_meter.Read(address, count, &data[0]), modb::ResponseError::None);
+    ASSERT_EQ(data[0], 0);
+    ASSERT_EQ(data[1], 0);
+}
+
+TEST_F(SunspecMeterModelTest, Read_InvalidAddress1706Count_ReturnsError)
+{
+    const auto address = 1706;
+    const auto count = 2;
+    std::vector<uint8_t> data(count * modb::REGISTER_SIZE);
     ASSERT_EQ(m_meter.Read(address, count, &data[0]), modb::ResponseError::IllegalAddress);
 }
 


### PR DESCRIPTION
After inverter sw update from 1.34.2-1 to 1.40.9-1 the smart meter is not recognized anymore. Fixed common block and start-address 768 and 1706 responses.